### PR TITLE
Feature guarded no_std support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: 
+    branches:
     - master
 
 env:
@@ -46,6 +46,10 @@ jobs:
     - name: check clippy
       if: ${{ matrix.rust == 'stable' && matrix.os == 'ubuntu-latest' }}
       run: cargo clippy --all --all-targets -- -D clippy::all && cargo clippy --no-default-features --features prost-codec -- -D clippy::all
+    - name: run tests with no-std enabled
+      # No-std implementation uses feature that can only be compiled by nightly version
+      if: ${{ matrix.rust == 'nightly' }}
+      run: cargo test --all --no-default-features --features=protobuf-codec --features=default-logger -- --nocapture
     - run: cargo test --all -- --nocapture
     # Validate benches still work.
     - run: cargo bench --all -- --test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       run: cargo fmt --all -- --check
     - name: check clippy
       if: ${{ matrix.rust == 'stable' && matrix.os == 'ubuntu-latest' }}
-      run: cargo clippy --all --all-targets -- -D clippy::all && cargo clippy --no-default-features --features prost-codec -- -D clippy::all
+      run: cargo clippy --all --all-targets -- -D clippy::all && cargo clippy --no-default-features --features prost-codec --features std -- -D clippy::all
     - name: run tests with no-std enabled
       # No-std implementation uses feature that can only be compiled by nightly version
       if: ${{ matrix.rust == 'nightly' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,4 @@ jobs:
     # Only package harness has failpoints tests.
     - run: cargo test --tests --features failpoints --package harness -- --nocapture
     # TODO: There is a bug in protobuf-build that cached size is not supported yet, so do not test harness.
-    - run: cargo test --no-default-features --features prost-codec -- --nocapture
+    - run: cargo test --no-default-features --features prost-codec --features std -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,15 @@ readme = "README.md"
 homepage = "https://github.com/tikv/raft-rs"
 documentation = "https://docs.rs/raft"
 description = "The rust language implementation of Raft algorithm."
-categories = ["algorithms", "database-implementations"]
+categories = ["algorithms", "database-implementations", "no-std"]
 edition = "2021"
 
 [workspace]
 members = ["proto", "harness", "datadriven"]
 
 [features]
-default = ["protobuf-codec", "default-logger"]
+default = ["protobuf-codec", "default-logger", "std"]
+std = []
 # Enable failpoints
 failpoints = ["fail/failpoints"]
 protobuf-codec = ["raft-proto/protobuf-codec", "bytes"]
@@ -37,6 +38,8 @@ slog = "2.2"
 slog-envlogger = { version = "2.1.0", optional = true }
 slog-stdlog = { version = "4", optional = true }
 slog-term = { version = "2.4.0", optional = true }
+spin = { version = "0.9.8"}
+hashbrown = { version = "0.14.0"}
 
 [dev-dependencies]
 criterion = "0.3"

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -12,7 +12,7 @@ categories = []
 edition = "2018"
 
 [features]
-default = ["protobuf-codec", "raft/default-logger"]
+default = ["protobuf-codec", "raft/default-logger", "raft/std"]
 # Enable failpoints
 failpoints = ["fail/failpoints"]
 protobuf-codec = ["raft/protobuf-codec"]

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -48,8 +48,8 @@ pub mod util {
     {
         fn from((voters, learners): (Iter1, Iter2)) -> Self {
             let mut conf_state = ConfState::default();
-            conf_state.mut_voters().extend(voters.into_iter());
-            conf_state.mut_learners().extend(learners.into_iter());
+            conf_state.mut_voters().extend(voters);
+            conf_state.mut_learners().extend(learners);
             conf_state
         }
     }

--- a/src/confchange/changer.rs
+++ b/src/confchange/changer.rs
@@ -1,5 +1,10 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+use alloc::borrow::ToOwned;
+use alloc::format;
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::eraftpb::{ConfChangeSingle, ConfChangeType};
 use crate::tracker::{Configuration, ProgressMap, ProgressTracker};
 use crate::{Error, Result};

--- a/src/confchange/datadriven_test.rs
+++ b/src/confchange/datadriven_test.rs
@@ -1,4 +1,6 @@
-use std::fmt::Write;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::fmt::Write;
 
 use crate::{default_logger, Changer, ProgressTracker};
 use datadriven::{run_test, walk};

--- a/src/confchange/restore.rs
+++ b/src/confchange/restore.rs
@@ -3,6 +3,8 @@
 // TODO: remove following line
 #![allow(dead_code)]
 
+use alloc::vec::Vec;
+
 use super::changer::Changer;
 use crate::eraftpb::{ConfChangeSingle, ConfChangeType, ConfState};
 use crate::tracker::ProgressTracker;

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::borrow::ToOwned;
+use alloc::format;
+
 pub use super::read_only::{ReadOnlyOption, ReadState};
 use super::util::NO_LIMIT;
 use super::{

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,32 +1,29 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
-use thiserror::Error;
+
+use crate::StdError;
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::fmt;
 
 /// The base error type for raft
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum Error {
     /// An IO error occurred
-    #[error("{0}")]
-    Io(#[from] std::io::Error),
+    #[cfg(feature = "std")]
+    Io(std::io::Error),
     /// A storage error occurred.
-    #[error("{0}")]
-    Store(#[from] StorageError),
+    Store(StorageError),
     /// Raft cannot step the local message.
-    #[error("raft: cannot step raft local message")]
     StepLocalMsg,
     /// The raft peer is not found and thus cannot step.
-    #[error("raft: cannot step as peer not found")]
     StepPeerNotFound,
     /// The proposal of changes was dropped.
-    #[error("raft: proposal dropped")]
     ProposalDropped,
     /// The configuration is invalid.
-    #[error("{0}")]
     ConfigInvalid(String),
     /// A protobuf message codec failed in some manner.
-    #[error("protobuf codec error {0:?}")]
-    CodecError(#[from] protobuf::ProtobufError),
+    CodecError(protobuf::ProtobufError),
     /// The node exists, but should not.
-    #[error("The node {id} already exists in the {set} set.")]
     Exists {
         /// The node id.
         id: u64,
@@ -34,7 +31,6 @@ pub enum Error {
         set: &'static str,
     },
     /// The node does not exist, but should.
-    #[error("The node {id} is not in the {set} set.")]
     NotExists {
         /// The node id.
         id: u64,
@@ -42,11 +38,63 @@ pub enum Error {
         set: &'static str,
     },
     /// ConfChange proposal is invalid.
-    #[error("{0}")]
     ConfChangeError(String),
     /// The request snapshot is dropped.
-    #[error("raft: request snapshot dropped")]
     RequestSnapshotDropped,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            #[cfg(feature = "std")]
+            Error::Io(ref e) => write!(f, "{}", e),
+            Error::Store(ref e) => write!(f, "{}", e),
+            Error::StepLocalMsg => write!(f, "raft: cannot step raft local message"),
+            Error::StepPeerNotFound => write!(f, "raft: cannot step as peer not found"),
+            Error::ProposalDropped => write!(f, "raft: proposal dropped"),
+            Error::ConfigInvalid(ref m) => write!(f, "{}", m),
+            Error::CodecError(ref e) => write!(f, "protobuf codec error {0:?}", e),
+            Error::Exists { id, set } => {
+                write!(f, "The node {id} already exists in the {set} set.")
+            }
+            Error::NotExists { id, set } => {
+                write!(f, "The node {id} is not in the {set} set.")
+            }
+            Error::ConfChangeError(ref m) => write!(f, "{}", m),
+            Error::RequestSnapshotDropped => write!(f, "raft: request snapshot dropped"),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match *self {
+            #[cfg(feature = "std")]
+            Error::Io(ref e) => Some(e),
+            Error::Store(ref e) => Some(e),
+            Error::CodecError(ref e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Error {
+        Error::Io(err)
+    }
+}
+
+impl From<StorageError> for Error {
+    fn from(err: StorageError) -> Error {
+        Error::Store(err)
+    }
+}
+
+impl From<protobuf::ProtobufError> for Error {
+    fn from(err: protobuf::ProtobufError) -> Error {
+        Error::CodecError(err)
+    }
 }
 
 impl PartialEq for Error {
@@ -56,6 +104,7 @@ impl PartialEq for Error {
             (Error::StepPeerNotFound, Error::StepPeerNotFound) => true,
             (Error::ProposalDropped, Error::ProposalDropped) => true,
             (Error::Store(ref e1), Error::Store(ref e2)) => e1 == e2,
+            #[cfg(feature = "std")]
             (Error::Io(ref e1), Error::Io(ref e2)) => e1.kind() == e2.kind(),
             (Error::StepLocalMsg, Error::StepLocalMsg) => true,
             (Error::ConfigInvalid(ref e1), Error::ConfigInvalid(ref e2)) => e1 == e2,
@@ -67,26 +116,41 @@ impl PartialEq for Error {
 }
 
 /// An error with the storage.
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum StorageError {
     /// The storage was compacted and not accessible
-    #[error("log compacted")]
     Compacted,
     /// The log is not available.
-    #[error("log unavailable")]
     Unavailable,
     /// The log is being fetched.
-    #[error("log is temporarily unavailable")]
     LogTemporarilyUnavailable,
     /// The snapshot is out of date.
-    #[error("snapshot out of date")]
     SnapshotOutOfDate,
     /// The snapshot is being created.
-    #[error("snapshot is temporarily unavailable")]
     SnapshotTemporarilyUnavailable,
     /// Some other error occurred.
-    #[error("unknown error {0}")]
-    Other(#[from] Box<dyn std::error::Error + Sync + Send>),
+    Other(Box<dyn StdError + Sync + Send>),
+}
+
+impl fmt::Display for StorageError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            StorageError::Compacted => write!(f, "log compacted"),
+            StorageError::Unavailable => write!(f, "log unavailable"),
+            StorageError::LogTemporarilyUnavailable => write!(f, "log is temporarily unavailable"),
+            StorageError::SnapshotOutOfDate => write!(f, "snapshot out of date"),
+            StorageError::SnapshotTemporarilyUnavailable => {
+                write!(f, "snapshot is temporarily unavailable")
+            }
+            StorageError::Other(ref e) => write!(f, "unknown error {}", e),
+        }
+    }
+}
+
+impl StdError for StorageError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        None
+    }
 }
 
 impl PartialEq for StorageError {
@@ -113,13 +177,12 @@ impl PartialEq for StorageError {
 }
 
 /// A result type that wraps up the raft errors.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 #[allow(clippy::eq_op)]
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io;
 
     #[test]
     fn test_error_equal() {
@@ -127,14 +190,6 @@ mod tests {
         assert_eq!(
             Error::Store(StorageError::Compacted),
             Error::Store(StorageError::Compacted)
-        );
-        assert_eq!(
-            Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "oh no!")),
-            Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "oh yes!"))
-        );
-        assert_ne!(
-            Error::Io(io::Error::new(io::ErrorKind::NotFound, "error")),
-            Error::Io(io::Error::new(io::ErrorKind::BrokenPipe, "error"))
         );
         assert_eq!(Error::StepLocalMsg, Error::StepLocalMsg);
         assert_eq!(
@@ -145,13 +200,28 @@ mod tests {
             Error::ConfigInvalid(String::from("config error")),
             Error::ConfigInvalid(String::from("other error"))
         );
-        assert_eq!(
-            Error::from(io::Error::new(io::ErrorKind::Other, "oh no!")),
-            Error::from(io::Error::new(io::ErrorKind::Other, "oh yes!"))
-        );
         assert_ne!(
             Error::StepPeerNotFound,
             Error::Store(StorageError::Compacted)
+        );
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_error_equal_std() {
+        use std::io;
+
+        assert_eq!(
+            Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "oh no!")),
+            Error::Io(io::Error::new(io::ErrorKind::UnexpectedEof, "oh yes!"))
+        );
+        assert_ne!(
+            Error::Io(io::Error::new(io::ErrorKind::NotFound, "error")),
+            Error::Io(io::Error::new(io::ErrorKind::BrokenPipe, "error"))
+        );
+        assert_eq!(
+            Error::from(io::Error::new(io::ErrorKind::Other, "oh no!")),
+            Error::from(io::Error::new(io::ErrorKind::Other, "oh yes!"))
         );
     }
 

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -16,6 +16,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::eraftpb::{Entry, Snapshot};
 use crate::util::entry_approximate_size;
 use slog::Logger;
@@ -215,6 +218,7 @@ mod test {
     use crate::eraftpb::{Entry, Snapshot, SnapshotMetadata};
     use crate::log_unstable::Unstable;
     use crate::util::entry_approximate_size;
+    use alloc::vec;
 
     fn new_entry(index: u64, term: u64) -> Entry {
         let mut e = Entry::default();

--- a/src/quorum.rs
+++ b/src/quorum.rs
@@ -4,8 +4,8 @@ pub mod datadriven_test;
 pub mod joint;
 pub mod majority;
 
-use std::collections::HashMap;
-use std::fmt::{self, Debug, Display, Formatter};
+use crate::HashMap;
+use core::fmt::{self, Debug, Display, Formatter};
 
 /// VoteResult indicates the outcome of a vote.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/quorum/datadriven_test.rs
+++ b/src/quorum/datadriven_test.rs
@@ -1,7 +1,11 @@
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use crate::quorum::{AckIndexer, AckedIndexer, Index};
 use crate::{default_logger, HashMap, HashSet, JointConfig, MajorityConfig};
+use core::fmt::Write;
 use datadriven::{run_test, TestData};
-use std::fmt::Write;
 
 fn test_quorum(data: &TestData) -> String {
     // Two majority configs. The first one is always used (though it may

--- a/src/quorum/joint.rs
+++ b/src/quorum/joint.rs
@@ -4,7 +4,7 @@ use super::{AckedIndexer, VoteResult};
 use crate::util::Union;
 use crate::HashSet;
 use crate::MajorityConfig;
-use std::cmp;
+use core::cmp;
 
 /// A configuration of two groups of (possibly overlapping) majority configurations.
 /// Decisions require the support of both majorities.
@@ -92,7 +92,7 @@ impl Configuration {
     /// Describe returns a (multi-line) representation of the commit indexes for the
     /// given lookuper.
     #[cfg(test)]
-    pub(crate) fn describe(&self, l: &impl AckedIndexer) -> String {
+    pub(crate) fn describe(&self, l: &impl AckedIndexer) -> alloc::string::String {
         MajorityConfig::new(self.ids().iter().collect()).describe(l)
     }
 }

--- a/src/quorum/majority.rs
+++ b/src/quorum/majority.rs
@@ -1,13 +1,16 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::{AckedIndexer, Index, VoteResult};
-use crate::{DefaultHashBuilder, HashSet};
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 
-use std::collections::hash_set::Iter;
-use std::fmt::Formatter;
-use std::mem::MaybeUninit;
-use std::ops::{Deref, DerefMut};
-use std::{cmp, slice, u64};
+use super::{AckedIndexer, Index, VoteResult};
+use crate::{DefaultHashBuilder, HashSet, HashSetIter};
+
+use core::fmt::Formatter;
+use core::mem::MaybeUninit;
+use core::ops::{Deref, DerefMut};
+use core::{cmp, slice, u64};
 
 /// A set of IDs that uses majority quorums to make decisions.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -15,8 +18,8 @@ pub struct Configuration {
     voters: HashSet<u64>,
 }
 
-impl std::fmt::Display for Configuration {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Configuration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "({})",
@@ -43,7 +46,7 @@ impl Configuration {
     }
 
     /// Returns an iterator over voters.
-    pub fn ids(&self) -> Iter<'_, u64> {
+    pub fn ids(&self) -> HashSetIter<'_, u64> {
         self.voters.iter()
     }
 
@@ -169,7 +172,9 @@ impl Configuration {
     /// ```
     #[cfg(test)]
     pub(crate) fn describe(&self, l: &impl AckedIndexer) -> String {
-        use std::fmt::Write;
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+        use core::fmt::Write;
 
         let n = self.voters.len();
         if n == 0 {

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -14,9 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
-use std::convert::TryFrom;
-use std::ops::{Deref, DerefMut};
+use alloc::vec::Vec;
+use core::cmp;
+use core::convert::TryFrom;
+use core::ops::{Deref, DerefMut};
 
 use crate::eraftpb::{
     ConfChange, ConfChangeV2, ConfState, Entry, EntryType, HardState, Message, MessageType,
@@ -874,7 +875,7 @@ impl<T: Storage> Raft<T> {
     pub fn inflight_buffers_size(&self) -> usize {
         let mut total_size = 0;
         for (_, pr) in self.prs().iter() {
-            total_size += pr.ins.buffer_capacity() * std::mem::size_of::<u64>();
+            total_size += pr.ins.buffer_capacity() * core::mem::size_of::<u64>();
         }
         total_size
     }

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -14,7 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use alloc::format;
+use core::cmp;
 
 use slog::warn;
 use slog::Logger;
@@ -662,17 +668,12 @@ impl<T: Storage> RaftLog<T> {
 
 #[cfg(test)]
 mod test {
-    use std::{
-        cmp,
-        panic::{self, AssertUnwindSafe},
-    };
+    use alloc::vec;
 
     use crate::default_logger;
     use crate::eraftpb;
-    use crate::errors::{Error, StorageError};
-    use crate::raft_log::{self, RaftLog};
+    use crate::raft_log::RaftLog;
     use crate::storage::{GetEntriesContext, MemStorage};
-    use protobuf::Message as PbMessage;
 
     fn new_entry(index: u64, term: u64) -> eraftpb::Entry {
         let mut e = eraftpb::Entry::default();
@@ -1151,8 +1152,14 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_slice() {
+        use crate::errors::{Error, StorageError};
+        use crate::raft_log;
+        use protobuf::Message as PbMessage;
+        use std::panic::{self, AssertUnwindSafe};
+
         let (offset, num) = (100u64, 100u64);
         let (last, half) = (offset + num, offset + num / 2);
         let halfe = new_entry(half, half);
@@ -1291,8 +1298,12 @@ mod test {
     ///     2. Append any new entries not already in the log
     /// If the given (index, term) does not match with the existing log:
     ///     return false
+    #[cfg(feature = "std")]
     #[test]
     fn test_log_maybe_append() {
+        use core::cmp;
+        use std::panic::{self, AssertUnwindSafe};
+
         let l = default_logger();
         let previous_ents = vec![new_entry(1, 1), new_entry(2, 2), new_entry(3, 3)];
         let (last_index, last_term, commit, persist) = (3u64, 3u64, 1u64, 3u64);
@@ -1512,8 +1523,11 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_commit_to() {
+        use std::panic::{self, AssertUnwindSafe};
+
         let l = default_logger();
         let previous_ents = vec![new_entry(1, 1), new_entry(2, 2), new_entry(3, 3)];
         let previous_commit = 2u64;
@@ -1540,8 +1554,11 @@ mod test {
     }
 
     // TestCompaction ensures that the number of log entries is correct after compactions.
+    #[cfg(feature = "std")]
     #[test]
     fn test_compaction() {
+        use std::panic::{self, AssertUnwindSafe};
+
         let l = default_logger();
         let tests = vec![
             // out of upper bound
@@ -1583,8 +1600,12 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_is_outofbounds() {
+        use crate::errors::{Error, StorageError};
+        use std::panic::{self, AssertUnwindSafe};
+
         let (offset, num) = (100u64, 100u64);
         let store = MemStorage::new();
         store
@@ -1637,8 +1658,11 @@ mod test {
         }
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn test_restore_snap() {
+        use std::panic::{self, AssertUnwindSafe};
+
         let store = MemStorage::new();
         store.wl().apply_snapshot(new_snapshot(100, 1)).expect("");
         let mut raft_log = RaftLog::new(store, default_logger());

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -20,7 +20,10 @@
 //! nodes but not the raft consensus itself. Generally, you'll interact with the
 //! RawNode first and use it to access the inner workings of the consensus protocol.
 
-use std::{collections::VecDeque, mem};
+use alloc::vec;
+use alloc::vec::Vec;
+use alloc::collections::VecDeque;
+use core::mem;
 
 use protobuf::Message as PbMessage;
 use raft_proto::ConfChangeI;
@@ -798,6 +801,7 @@ impl<T: Storage> RawNode<T> {
 #[cfg(test)]
 mod test {
     use crate::eraftpb::MessageType;
+    use alloc::vec;
 
     use super::is_local_msg;
 

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -20,9 +20,9 @@
 //! nodes but not the raft consensus itself. Generally, you'll interact with the
 //! RawNode first and use it to access the inner workings of the consensus protocol.
 
+use alloc::collections::VecDeque;
 use alloc::vec;
 use alloc::vec::Vec;
-use alloc::collections::VecDeque;
 use core::mem;
 
 use protobuf::Message as PbMessage;

--- a/src/read_only.rs
+++ b/src/read_only.rs
@@ -14,7 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use slog::Logger;
 

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -26,8 +26,8 @@ use crate::confchange::{MapChange, MapChangeType};
 use crate::eraftpb::ConfState;
 use crate::quorum::{AckedIndexer, Index, VoteResult};
 use crate::{DefaultHashBuilder, HashMap, HashSet, JointConfig};
+use core::fmt::Debug;
 use getset::Getters;
-use std::fmt::Debug;
 
 /// Config reflects the configuration tracked in a ProgressTracker.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Getters)]
@@ -90,8 +90,14 @@ pub struct Configuration {
 
 // Display and crate::itertools used only for test
 #[cfg(test)]
-impl std::fmt::Display for Configuration {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Configuration {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        #[cfg(not(feature = "std"))]
+        use alloc::string::String;
+        #[cfg(not(feature = "std"))]
+        use alloc::string::ToString;
+        #[cfg(not(feature = "std"))]
+        use alloc::vec::Vec;
         use itertools::Itertools;
         if self.voters.outgoing.is_empty() {
             write!(f, "voters={}", self.voters.incoming)?

--- a/src/tracker/inflights.rs
+++ b/src/tracker/inflights.rs
@@ -14,7 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::Ordering;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use core::cmp::Ordering;
 
 /// A buffer of inflight messages.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -204,6 +207,8 @@ impl Inflights {
 #[cfg(test)]
 mod tests {
     use super::Inflights;
+    use alloc::vec;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_inflight_add() {

--- a/src/tracker/progress.rs
+++ b/src/tracker/progress.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::{Inflights, ProgressState, INVALID_INDEX};
-use std::cmp;
+use core::cmp;
 
 /// The progress of catching up from a restart.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -244,6 +244,7 @@ impl Progress {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     fn new_progress(
         state: ProgressState,

--- a/src/tracker/state.rs
+++ b/src/tracker/state.rs
@@ -14,8 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-use std::fmt::{Display, Formatter};
+use core::fmt;
+use core::fmt::{Display, Formatter};
 
 /// The state of the progress.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,9 +3,12 @@
 
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::fmt;
-use std::fmt::Write;
-use std::u64;
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+use core::fmt::Write;
+use core::u64;
 
 use slog::{OwnedKVList, Record, KV};
 


### PR DESCRIPTION
---
name: no_std
about: Supporting no_std compilation mode

---

**Description of feature:**
Make the library compatible with no_std environments.

**Implementation:**
The std target implementation remains unchanged. The majority of changes are switching to using core and alloc where std used to be. The no_std flavor uses no_std compatible collections and synchronization primitives. The thiserror crate doesn't have no_std support hence the error types where reimplemented manually.